### PR TITLE
connection drain event

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,19 +181,20 @@ is inactive for a configurable period of time (see inactivityTimeout); it will
 be reopened when needed again. Disconnection can be either a result of socket inactivity or a network failure.
 
 #### `'drain'`, `'finish'`, `'pipe'`, and `'unpipe'`
-These are events inherited from `Writable`. Note that the drain event here is
-not the one you want to listen for if you’re interested in confirming that all
-pending data has **transmitted** -- for that, listen to `'connection drain'`.
+These are events inherited from `Writable`.
 
 #### `'connection drain'`
-This is the propagated drain event of the current underlying connection stream.
+DEPRECATED. Use `buffer drain` event instead.
+
+#### `'buffer drain'`
+This event is emitted when the underlying ring buffer is fully consumed and becomes empty.
 This can be useful when it’s time for the application to terminate but you want
 to be sure any pending logs have finished writing.
 
 ```javascript
 process.on('SIGINT', () => {
    logger.notice({ type: 'server', event: 'shutdown' });
-   logger.once('connection drain', () => process.exit());
+   logger.once('buffer drain', () => process.exit());
 });
 ```
 

--- a/src/ringbuffer.js
+++ b/src/ringbuffer.js
@@ -5,6 +5,7 @@ class RingBuffer extends EventEmitter {
     super();
     this.records = [];
     this.limit = limit;
+    this.bufferWasFull = false;
   }
 
   write(log) {
@@ -12,14 +13,22 @@ class RingBuffer extends EventEmitter {
     if (this.records.length > this.limit) {
       this.records.shift();
 
-      this.emit('buffer shift');
+      if (!this.bufferWasFull) {
+        this.emit('buffer shift');
+        this.bufferWasFull = true;
+      }
       return false;
     }
     return true;
   }
 
   read() {
+    this.bufferWasFull = false;
     return this.records.shift();
+  }
+
+  isEmpty() {
+    return this.records.length === 0;
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -582,7 +582,7 @@ tape('RingBuffer buffers and shifts when it is full', function (t) {
   t.true(ringBuffer.write('Test log'), 'RingBuffer buffers');
   t.false(ringBuffer.write('Another test log'), 'RingBuffer shifts');
   t.equal(ringBuffer.read(), 'Another test log', 'got expected log event');
-  t.equal(0, ringBuffer.records.length, 'No records left in the buffer');
+  t.true(ringBuffer.isEmpty(), 'No records left in the buffer');
 });
 
 // WINSTON TRANSPORT


### PR DESCRIPTION
- deprecated connection drain event and introduced buffer drain event instead. this will make sure that all the events will be pushed to tcp socket before the buffer drain event is emitted.

- moved the 'buffer shift' event logic to ringbuffer module.