### PR TITLE
Krzkaczor/winston fixes

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -697,6 +697,7 @@ class Logger extends Writable {
       constructor(opts) {
         super(opts);
         this.json = opts.json;
+        this.name = 'logentries';
 
         const transportOpts = _.clone(opts || {});
 
@@ -750,10 +751,6 @@ class Logger extends Writable {
         }
 
         setImmediate(cb.bind(null, null, true));
-      }
-
-      get name() {
-        return 'logentries';
       }
 
       get tempLevel() {

--- a/src/logger.js
+++ b/src/logger.js
@@ -739,7 +739,7 @@ class Logger extends Writable {
           this.logger.log(lvl, message);
         } else {
           let message = msg;
-          if (!_.isEmpty(meta)) {
+          if (!_.isEmpty(meta) || _.isError(meta)) {
             if (_.isString(message)) {
               message += ` ${this.logger.serialize(meta)}`;
             } else if (_.isObject(message)) {


### PR DESCRIPTION
Fixes #141 and #138 

More about #141
Winston requires that name has valid setter.

More about #138:
Passing error instance to lodash `isEmpty` returns true. 