### PR TITLE
Test against Node.js v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: "node_js"
 node_js:
+ - "7"
  - "6"
  - "5"
  - "4"


### PR DESCRIPTION
Add Node.js v7 to CI.

Also note that Node.js v5 is no longer supported, but I did not remove it.