### PR TITLE
Bump mitm for node v7 fix for renamed function. Add v7 to ran tests i…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: "node_js"
 node_js:
+ - "7"
  - "6"
  - "5"
  - "4"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gobble-babel": "6.0.0",
     "gobble-cli": "0.6.0",
     "install": "0.6.1",
-    "mitm": "1.1.0",
+    "mitm": "1.3.2",
     "npm": "3.8.2",
     "tap-spec": "3.0.0",
     "tape": "4.0.0",


### PR DESCRIPTION
…n travis.

Mitm had a undefined reference due to a function name change in the v7 node version. They have a fix so just bumping the version to get it.

This is a fix for #144 