### PR TITLE
Support for prepending hostname to logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ accessors, though, and invalid values will be ignored.
    serialization. Applied before error transformation.
  - **timestamp**: If truthy, prefix entries with an ISO timestamp (if strings)
    or add the same as a property (if objects). Default: `false`.
+ - **withHostname**: Will prepend(string) or add property (object) indicating the 
+   hostname from which the log was sent.
  - **withLevel**: Will prepend (string) or add property (object) indicating the
    log level. Default: `true`.
  - **withStack**: If an object is or contains an `Error` object, setting this to

--- a/test/test.js
+++ b/test/test.js
@@ -163,6 +163,24 @@ tape('Logger allows specification of minLevel at construction', function (t) {
 
 });
 
+
+tape('Logger allows specification of withHostname at construction', function (t) {
+
+  const logger1 = new Logger({ token: x, withHostname: true });
+
+  t.equal(logger1.withHostname, true, 'withHostname');
+
+  const logger2 = new Logger({ token: x });
+
+  t.equal(logger2.withHostname, false, 'withHostname');
+
+  t.end();
+
+});
+
+
+
+
 // CUSTOM JSON SERIALIZATION
 
 tape('Error objects are serialized nicely.', function (t) {
@@ -464,6 +482,45 @@ tape('Non-JSON logs may carry timestamp.', function (t) {
 
   logger[lvl]('test');
 });
+
+
+tape('Non-JSON logs may carry Hostname.', function (t) {
+  t.plan(1);
+  t.timeoutAfter(2000);
+
+  mockTest(function (data) {
+    t.true(pattern.test(data), 'matched');
+
+  });
+  const os = require('os');
+  const lvl = defaults.levels[3];
+  const tkn = x;
+  const pattern = new RegExp('^' + x +' ' + os.hostname() + ' \\w+ test\\n$'
+  );
+
+  const logger = new Logger({ token: tkn, withHostname: true });
+
+  logger[lvl]('test');
+});
+
+
+tape('JSON logs may carry Hostname.', function (t) {
+  t.plan(1);
+  t.timeoutAfter(2000);
+
+  mockTest(function (data) {
+    const log = JSON.parse(data.substr(37));
+    t.true(log.host, 'has property');
+  });
+  const os = require('os');
+  const lvl = defaults.levels[3];
+  const tkn = x;
+
+  const logger = new Logger({ token: tkn, withHostname: true });
+
+  logger[lvl]({msg: "Testing!"});
+});
+
 
 tape('JSON logs match expected pattern.', function (t) {
   t.timeoutAfter(2000);


### PR DESCRIPTION
This adds support for a new option **withHostname** which will prepend the current server's hostname to each log entry.

Hostname is discovered via ```os.hostname()```