### PR TITLE
upgrade lodash to fix audit issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "le_node",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Logentries client for node; use with or without Winston or Bunyan.",
   "keywords": [
     "logentries",
@@ -46,7 +46,7 @@
     "babel-runtime": "6.6.1",
     "codependency": "0.1.4",
     "json-stringify-safe": "5.0.1",
-    "lodash": "4.17.11",
+    "lodash": "4.17.12",
     "semver": "5.1.0",
     "reconnect-core": "1.3.0"
   },


### PR DESCRIPTION
lodash <= 4.7.11 has a high-severity npm audit issue, fixed in 4.7.12